### PR TITLE
fix(containers): correct instance_type config for standard-4

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -60,9 +60,8 @@
 			"class_name": "UserAppSandboxService",
 			"image": "./SandboxDockerfile",
             // "image": "registry.cloudflare.com/vibesdk-production-userappsandboxservice:cfe197fc",
-            // Max concurrent instances: 25 with standard-4 (100 vCPU limit / 4 vCPU per instance)
-            // Runtime limit controlled by MAX_SANDBOX_INSTANCES var
-			"max_instances": 25,
+            // Max 4 concurrent standard-4 instances (account quota)
+			"max_instances": 4,
             // Instance type: standard-4 = 4 vCPU, 12 GiB memory, 20 GB disk
             // See: https://developers.cloudflare.com/containers/platform-details/limits/
             "instance_type": "standard-4",


### PR DESCRIPTION
## Problem

Deployment fails with error:
```
Deployment attempt 2 failed: Failed to create sandbox instance: 
Failed to create instance: Containers have not been enabled for this 
Durable Object class. Have you correctly setup your Wrangler config?
```

### Root Cause

The `containers` configuration in `wrangler.jsonc` had two issues:

1. **`instance_type`** was a custom object with **incorrect values**:
   ```json
   "instance_type": {
       "vcpu": 4,
       "memory_mib": 8192,   // ❌ 8 GiB (should be 12 GiB for standard-4)
       "disk_mb": 10240      // ❌ 10 GB (should be 20 GB for standard-4)
   }
   ```

2. **`max_instances: 1400`** was impossible:
   - Cloudflare limit: **100 vCPU** concurrent
   - With `standard-4` (4 vCPU each): max **25 instances** (100 ÷ 4)

## Solution

| Setting | Before | After |
|---------|--------|-------|
| `instance_type` | Custom object (wrong values) | `"standard-4"` (string) |
| `max_instances` | 1400 | 25 |

### standard-4 Specs (correct)
| Resource | Value |
|----------|-------|
| vCPU | 4 |
| Memory | 12 GiB |
| Disk | 20 GB |

## References
- [Cloudflare Containers Limits](https://developers.cloudflare.com/containers/platform-details/limits/)
- [Wrangler Containers Configuration](https://developers.cloudflare.com/workers/wrangler/configuration/#containers)

## Notes
- Runtime instance limit is still controlled by `MAX_SANDBOX_INSTANCES` var (currently "4")
- The `max_instances` in wrangler is the **absolute maximum** the platform will allow