### PR TITLE
fix: enable preview URLs and fix domain routing

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -97,7 +97,8 @@
       {
         "binding": "TEMPLATES_BUCKET",
         "bucket_name": "vibesdk-templates",
-        "remote": true,"preview_bucket_name": "vibesdk-templates"
+        "remote": true,
+        "preview_bucket_name": "vibesdk-templates"
       }
     ],
     "kv_namespaces": [
@@ -127,13 +128,8 @@
 	],
 	"routes": [
         {
-            "pattern": "build.cloudflare.dev",
+            "pattern": "build.voither.com",
             "custom_domain": true
-        },
-        {
-            "pattern": "*build-preview.cloudflare.dev/*",
-            "custom_domain": false,
-            "zone_id": "db01fac4261b2604aacad8410443a3e2"
         }
     ],
 	"vars": {
@@ -148,6 +144,6 @@
         "SANDBOX_INSTANCE_TYPE": "standard-4",
         "USE_CLOUDFLARE_IMAGES": "true"
     },
-	"workers_dev": false,
-	"preview_urls": false
+	"workers_dev": true,
+	"preview_urls": true
 }


### PR DESCRIPTION
## 🐛 Problem

Preview URLs never become available for sandbox instances. UI shows eternal "Loading Preview" state with retry messages.

## 🔍 Root Cause

Found **3 configuration issues** in `wrangler.jsonc`:

| Setting | Before | After |
|---------|--------|-------|
| `preview_urls` | `false` ❌ | `true` ✅ |
| `workers_dev` | `false` ❌ | `true` ✅ |
| Routes | `build.cloudflare.dev` ❌ | `build.voither.com` ✅ |

## 🔧 Changes

1. **Enabled preview URLs** - Required for `sandbox.exposePort()` to generate accessible URLs
2. **Enabled workers_dev** - Required for Workers subdomain functionality  
3. **Fixed routes** - Changed from Cloudflare's domains to your custom domain `build.voither.com`

## 📋 Technical Context

The sandbox SDK uses:
```typescript
const previewResult = await sandbox.exposePort(allocatedPort, { 
    hostname: getPreviewDomain(env)  // Returns "build.voither.com"
});
```

With `preview_urls: false`, exposed container ports cannot generate accessible URLs.

## 🧪 After Merging

1. `wrangler deploy`
2. Create a new sandbox instance
3. Preview URL should now become available

Fixes #13