### PR TITLE
fix: add wildcard route for Container preview URLs

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -130,6 +130,12 @@
         {
             "pattern": "build.voither.com",
             "custom_domain": true
+        },
+        {
+            // Wildcard route for Container preview URLs
+            // Requires DNS record: *.build.voither.com -> 100:: (proxied)
+            "pattern": "*.build.voither.com/*",
+            "zone_id": "018e17f21e9ad23b24ff894908be4149"
         }
     ],
 	"vars": {


### PR DESCRIPTION
## Summary
Adds wildcard route configuration to enable sandbox Container preview URLs.

## Changes
- Added wildcard route `*.build.voither.com/*` with zone_id to `wrangler.jsonc`

## DNS Configuration (Already Applied)
Created DNS record via Cloudflare API:
- **Type:** AAAA
- **Name:** `*.build.voither.com`
- **Content:** `100::`
- **Proxied:** Yes

## Why This Is Needed
Cloudflare Containers require wildcard DNS routing for preview URLs. The format is:
```
https://{port}-{sandbox-id}.build.voither.com
```

Without the wildcard route + DNS record, `sandbox.exposePort()` cannot generate working preview URLs.

## References
- [Cloudflare Sandbox Production Deployment](https://developers.cloudflare.com/sandbox/guides/production-deployment/)
- [Preview URLs Concept](https://developers.cloudflare.com/sandbox/concepts/preview-urls/)