### PR TITLE
fix: use previews.voither.com for Container preview URLs (SSL fix)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -132,9 +132,9 @@
             "custom_domain": true
         },
         {
-            // Wildcard route for Container preview URLs
-            // Requires DNS record: *.build.voither.com -> 100:: (proxied)
-            "pattern": "*.build.voither.com/*",
+            // Route for Container preview URLs
+            // Uses previews.voither.com (covered by *.voither.com SSL cert)
+            "pattern": "previews.voither.com/*",
             "zone_id": "018e17f21e9ad23b24ff894908be4149"
         }
     ],
@@ -146,6 +146,7 @@
         "CLOUDFLARE_AI_GATEWAY": "voither",
         "PLATFORM_MODEL_PROVIDERS": "anthropic,google-ai-studio,openai,grok,google-vertex-ai",
         "CUSTOM_DOMAIN": "build.voither.com",
+        "CUSTOM_PREVIEW_DOMAIN": "previews.voither.com",
         "MAX_SANDBOX_INSTANCES": "4",
         "SANDBOX_INSTANCE_TYPE": "standard-4",
         "USE_CLOUDFLARE_IMAGES": "true"


### PR DESCRIPTION
## Problem
Preview URLs não funcionavam porque `*.build.voither.com` precisa de certificado SSL multi-nível (Advanced Certificate Manager), que não está ativado na zona.

## Solution
Usar `previews.voither.com` como domínio de preview - é um subdomínio de primeiro nível coberto pelo certificado universal `*.voither.com`.

## Changes
- Route mudou de `*.build.voither.com/*` para `previews.voither.com/*`
- Adicionado `CUSTOM_PREVIEW_DOMAIN: "previews.voither.com"`

## Infrastructure Already Applied
- DNS: `previews.voither.com → 100::` (proxied) ✅
- Route: `previews.voither.com/*` → vibesdk-0 ✅
- SSL: Coberto por `*.voither.com` universal cert ✅

## Preview URL Format
Agora será: `https://previews.voither.com/{port}-{sandbox-id}/`